### PR TITLE
Affichage du logo : fas fa-tachometer-alt

### DIFF
--- a/desktop/php/espeasy.php
+++ b/desktop/php/espeasy.php
@@ -82,7 +82,7 @@ if ($state == 1) {
  <a class="btn btn-default eqLogicAction pull-right" data-action="copy"><i class="fas fa-files-o"></i> {{Dupliquer}}</a>
  <ul class="nav nav-tabs" role="tablist">
   <li role="presentation"><a href="#" class="eqLogicAction" aria-controls="home" role="tab" data-toggle="tab" data-action="returnToThumbnailDisplay"><i class="fas fa-arrow-circle-left"></i></a></li>
-  <li role="presentation" class="active"><a href="#eqlogictab" aria-controls="home" role="tab" data-toggle="tab"><i class="fas fa-tachometer"></i> {{Equipement}}</a></li>
+  <li role="presentation" class="active"><a href="#eqlogictab" aria-controls="home" role="tab" data-toggle="tab"><i class="fas fa-tachometer-alt"></i> {{Equipement}}</a></li>
   <li role="presentation"><a href="#commandtab" aria-controls="profile" role="tab" data-toggle="tab"><i class="fas fa-list-alt"></i> {{Commandes}}</a></li>
 </ul>
 <div class="tab-content" style="height:calc(100% - 50px);overflow:auto;overflow-x: hidden;">


### PR DESCRIPTION
`fas fa-tachometer` n'existe pas. Et n'est donc pas affiché sur jeedo