### PR TITLE
Follow internal redirect

### DIFF
--- a/resources/espeasy.js
+++ b/resources/espeasy.js
@@ -14,6 +14,7 @@ function answer(req, res) {
     urlj = urlJeedom + "&" + decodeUrl+ "&ip=" + ipString;
     if (loglevel <= 100) {console.log("Calling Jeedom " + urlj);} // DEBUG
   	request({
+		followAllRedirects: true,
   		url: urlj,
   		method: 'PUT',
   	},


### PR DESCRIPTION
Bonjour,

Pour des besoins de sécu, je redirige les requêtes adressées à 127.0.0.1 vers le nom DNS.
A cause de ça, le plugin ESPeasy ne fonctionne plus car il ne suis pas les redirections.

Est-ce possible dans une futur version de rajouter un petit « followAllRedirects: true » dans espeasy.js ?

C’est une modification qui, dans la limite des connaissance, n’affectera en rien le fonctionnement.

Merci par avance.